### PR TITLE
アスペクト比を考慮して画像をスクリーンに描画するサンプル

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,6 +2626,7 @@ dependencies = [
 name = "wgsim"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "env_logger",
  "futures-intrusive",
  "gif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ wgpu              = "23.0.1"
 winit             = "0.30.7"
 
 [dev-dependencies]
+bytemuck   = "1.21.0"
 env_logger = "0.11.6"
 image      = "0.25.5"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## wgsim
 
-A simple wgpu and winit wrapper for personal use
+A simple [wgpu](https://github.com/gfx-rs/wgpu) and [winit](https://github.com/rust-windowing/winit) wrapper for personal use
 
 ### Examples
 
@@ -8,4 +8,10 @@ Fullscreen image rendering:
 
 ```bash
 cargo run --example screen-image
+```
+
+Fullscreen image rendering with `object-fit: contain;` style:
+
+```bash
+cargo run --example screen-fit-contain-image
 ```

--- a/examples/screen-fit-contain-image/main.rs
+++ b/examples/screen-fit-contain-image/main.rs
@@ -7,6 +7,7 @@ use image::GenericImageView;
 use wgsim::app::App;
 use wgsim::ctx::DrawingContext;
 use wgsim::ppl::RenderPipelineBuilder;
+use wgsim::primitive::Size;
 use wgsim::render::Render;
 use wgsim::util;
 
@@ -52,6 +53,8 @@ struct Initial {
 struct State {
   render_result_bind_group: wgpu::BindGroup,
   render_result_pipeline: wgpu::RenderPipeline,
+
+  need_resolution_update: bool,
 }
 
 impl<'a> Render<'a> for State {
@@ -154,6 +157,15 @@ impl<'a> Render<'a> for State {
     Self {
       render_result_bind_group,
       render_result_pipeline,
+
+      need_resolution_update: false,
+    }
+  }
+
+  fn resize(&mut self, ctx: &mut DrawingContext, size: Size) {
+    if size.width > 0 && size.height > 0 {
+      ctx.resize(size);
+      self.need_resolution_update = true;
     }
   }
 

--- a/examples/screen-fit-contain-image/main.rs
+++ b/examples/screen-fit-contain-image/main.rs
@@ -1,0 +1,161 @@
+use std::error::Error;
+
+use image::GenericImageView;
+
+use wgsim::app::App;
+use wgsim::ctx::DrawingContext;
+use wgsim::ppl::RenderPipelineBuilder;
+use wgsim::render::Render;
+use wgsim::util;
+
+const SAMPLER_BINDING_TYPE: wgpu::BindingType =
+  wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering);
+
+const TEXTURE_BINDING_TYPE: wgpu::BindingType = wgpu::BindingType::Texture {
+  sample_type: wgpu::TextureSampleType::Float { filterable: true },
+  view_dimension: wgpu::TextureViewDimension::D2,
+  multisampled: false,
+};
+
+fn main() -> Result<(), Box<dyn Error>> {
+  env_logger::init();
+
+  let initial = setup();
+
+  let mut app: App<State> = App::new("screen-fit-contain-image", initial);
+  app.run()?;
+
+  Ok(())
+}
+
+fn setup() -> Initial {
+  let img_bytes = include_bytes!("../assets/img/pastel-tomixy.png");
+  let image = image::load_from_memory(img_bytes).unwrap();
+  let image_size = image.dimensions();
+
+  Initial { image, image_size }
+}
+
+struct Initial {
+  image: image::DynamicImage,
+  image_size: (u32, u32),
+}
+
+struct State {
+  render_result_bind_group: wgpu::BindGroup,
+  render_result_pipeline: wgpu::RenderPipeline,
+}
+
+impl<'a> Render<'a> for State {
+  type Initial = Initial;
+
+  async fn new(ctx: &DrawingContext<'a>, initial: &Self::Initial) -> Self {
+    let render_shader =
+      ctx.device.create_shader_module(wgpu::include_wgsl!("./render.wgsl"));
+
+    let src_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+      label: Some("src texture"),
+      size: wgpu::Extent3d {
+        width: initial.image_size.0,
+        height: initial.image_size.1,
+        depth_or_array_layers: 1,
+      },
+      mip_level_count: 1,
+      sample_count: 1,
+      dimension: wgpu::TextureDimension::D2,
+      format: wgpu::TextureFormat::Rgba8UnormSrgb, // 元画像の色味を保つため、ここだけsRGB
+      usage: wgpu::TextureUsages::COPY_DST
+        | wgpu::TextureUsages::RENDER_ATTACHMENT
+        | wgpu::TextureUsages::TEXTURE_BINDING,
+      view_formats: &[],
+    });
+
+    ctx.queue.write_texture(
+      src_texture.as_image_copy(),
+      &initial.image.to_rgba8(),
+      wgpu::ImageDataLayout {
+        offset: 0,
+        bytes_per_row: Some(4 * initial.image_size.0),
+        rows_per_image: Some(initial.image_size.1),
+      },
+      wgpu::Extent3d {
+        width: initial.image_size.0,
+        height: initial.image_size.1,
+        depth_or_array_layers: 1,
+      },
+    );
+
+    let sampler = ctx.device.create_sampler(&wgpu::SamplerDescriptor {
+      label: Some("sampler"),
+      mag_filter: wgpu::FilterMode::Linear,
+      min_filter: wgpu::FilterMode::Linear,
+      ..Default::default()
+    });
+
+    let render_result_bind_group_layout = util::create_bind_group_layout(
+      &ctx.device,
+      &[SAMPLER_BINDING_TYPE, TEXTURE_BINDING_TYPE],
+      &[wgpu::ShaderStages::FRAGMENT, wgpu::ShaderStages::FRAGMENT],
+    );
+
+    let render_result_bind_group = util::create_bind_group(
+      &ctx.device,
+      &render_result_bind_group_layout,
+      &[
+        wgpu::BindingResource::Sampler(&sampler),
+        wgpu::BindingResource::TextureView(
+          &src_texture.create_view(&wgpu::TextureViewDescriptor::default()),
+        ),
+      ],
+    );
+
+    let render_result_pipeline_layout =
+      ctx.device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("render result pipeline layout"),
+        bind_group_layouts: &[&render_result_bind_group_layout],
+        push_constant_ranges: &[],
+      });
+
+    let render_result_pipeline = RenderPipelineBuilder::new(&ctx)
+      .vs_shader(&render_shader, "vs_main")
+      .fs_shader(&render_shader, "fs_main")
+      .pipeline_layout(&render_result_pipeline_layout)
+      .build();
+
+    Self {
+      render_result_bind_group,
+      render_result_pipeline,
+    }
+  }
+
+  fn draw(
+    &mut self,
+    encoder: &mut wgpu::CommandEncoder,
+    render_target_view: &wgpu::TextureView,
+    _sample_count: u32,
+  ) -> Result<(), wgpu::SurfaceError> {
+    let color_attachment = wgpu::RenderPassColorAttachment {
+      view: render_target_view,
+      resolve_target: None,
+      ops: wgpu::Operations {
+        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+        store: wgpu::StoreOp::Store,
+      },
+    };
+
+    let mut render_pass =
+      encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("render pass"),
+        color_attachments: &[Some(color_attachment)],
+        ..Default::default()
+      });
+
+    render_pass.set_pipeline(&self.render_result_pipeline);
+    render_pass.set_bind_group(0, &self.render_result_bind_group, &[]);
+    render_pass.draw(0..6, 0..1);
+
+    drop(render_pass);
+
+    Ok(())
+  }
+}

--- a/examples/screen-fit-contain-image/main.rs
+++ b/examples/screen-fit-contain-image/main.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::time::Duration;
 
 use wgpu::util::DeviceExt;
 
@@ -54,6 +55,7 @@ struct State {
   render_result_bind_group: wgpu::BindGroup,
   render_result_pipeline: wgpu::RenderPipeline,
 
+  resolution_uniform_buffer: wgpu::Buffer,
   need_resolution_update: bool,
 }
 
@@ -158,6 +160,7 @@ impl<'a> Render<'a> for State {
       render_result_bind_group,
       render_result_pipeline,
 
+      resolution_uniform_buffer,
       need_resolution_update: false,
     }
   }
@@ -166,6 +169,21 @@ impl<'a> Render<'a> for State {
     if size.width > 0 && size.height > 0 {
       ctx.resize(size);
       self.need_resolution_update = true;
+    }
+  }
+
+  fn update(&mut self, ctx: &DrawingContext, _dt: Duration) {
+    if self.need_resolution_update {
+      let resolution = ctx.resolution();
+      ctx.queue.write_buffer(
+        &self.resolution_uniform_buffer,
+        0,
+        bytemuck::cast_slice(&[
+          resolution.width as f32,
+          resolution.height as f32,
+        ]),
+      );
+      self.need_resolution_update = false;
     }
   }
 

--- a/examples/screen-fit-contain-image/render.wgsl
+++ b/examples/screen-fit-contain-image/render.wgsl
@@ -1,20 +1,42 @@
 @group(0) @binding(0) var screen_sampler: sampler;
 @group(0) @binding(1) var screen_texture: texture_2d<f32>;
+@group(0) @binding(2) var<uniform> resolution: vec2f;
 
 struct VertexOutput {
   @builtin(position) position: vec4f,
   @location(0) uv: vec2f,
 }
 
+fn fit_contain(pos: vec2f, tex_sc_ratio: f32) -> vec2f {
+  var scale: vec2<f32>;
+
+  if (tex_sc_ratio < 1.0) {
+    // テクスチャがスクリーンに比べて横長
+    scale = vec2<f32>(tex_sc_ratio, 1.0);
+  } else {
+    // テクスチャがスクリーンに比べて縦長または同じ比率
+    scale = vec2<f32>(1.0, 1.0 / tex_sc_ratio);
+  }
+
+  return pos * scale;
+}
+
 @vertex
 fn vs_main(@builtin(vertex_index) i: u32) -> VertexOutput {
+  let tex_size = textureDimensions(screen_texture, 0);
+
+  let tex_aspect = f32(tex_size.x) / f32(tex_size.y);
+  let screen_aspect = resolution.x / resolution.y;
+
+  let tex_sc_ratio = tex_aspect / screen_aspect;
+  
   var pos = array<vec2f, 6>(
-    vec2f( 1.0,  1.0),
-    vec2f( 1.0, -1.0),
-    vec2f(-1.0, -1.0),
-    vec2f( 1.0,  1.0),
-    vec2f(-1.0, -1.0),
-    vec2f(-1.0,  1.0),
+    fit_contain(vec2f( 1.0,  1.0), tex_sc_ratio),
+    fit_contain(vec2f( 1.0, -1.0), tex_sc_ratio),
+    fit_contain(vec2f(-1.0, -1.0), tex_sc_ratio),
+    fit_contain(vec2f( 1.0,  1.0), tex_sc_ratio),
+    fit_contain(vec2f(-1.0, -1.0), tex_sc_ratio),
+    fit_contain(vec2f(-1.0,  1.0), tex_sc_ratio),
   );
   
   var uv = array<vec2f, 6>(

--- a/examples/screen-fit-contain-image/render.wgsl
+++ b/examples/screen-fit-contain-image/render.wgsl
@@ -1,0 +1,38 @@
+@group(0) @binding(0) var screen_sampler: sampler;
+@group(0) @binding(1) var screen_texture: texture_2d<f32>;
+
+struct VertexOutput {
+  @builtin(position) position: vec4f,
+  @location(0) uv: vec2f,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) i: u32) -> VertexOutput {
+  var pos = array<vec2f, 6>(
+    vec2f( 1.0,  1.0),
+    vec2f( 1.0, -1.0),
+    vec2f(-1.0, -1.0),
+    vec2f( 1.0,  1.0),
+    vec2f(-1.0, -1.0),
+    vec2f(-1.0,  1.0),
+  );
+  
+  var uv = array<vec2f, 6>(
+    vec2f(1.0, 0.0),
+    vec2f(1.0, 1.0),
+    vec2f(0.0, 1.0),
+    vec2f(1.0, 0.0),
+    vec2f(0.0, 1.0),
+    vec2f(0.0, 0.0),
+  );
+  
+  var output: VertexOutput;
+  output.position = vec4(pos[i], 0.0, 1.0);
+  output.uv = uv[i];
+  return output;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+  return textureSample(screen_texture, screen_sampler, in.uv);
+}


### PR DESCRIPTION
```bash
cargo run --example screen-fit-contain-image
```

<img width="537" alt="スクリーンショット 2024-12-30 7 35 20" src="https://github.com/user-attachments/assets/2e82e2cc-36c0-427f-861a-5115ce9c1c97" />
<img width="912" alt="スクリーンショット 2024-12-30 7 35 13" src="https://github.com/user-attachments/assets/6ef62efb-f823-4a2c-9b31-2dcde199f7ba" />
